### PR TITLE
Fix signature sticking to cursor (ENL2020-1260)

### DIFF
--- a/src/event-listeners/onLocationSelected.js
+++ b/src/event-listeners/onLocationSelected.js
@@ -30,7 +30,7 @@ export default store => evt => {
       sig.CustomData.widgetId = id;
       sig.setCustomData('widgetId', id);
       signatureTool.setSignature(sig);
-      
+
       return new Promise(res => setTimeout(() => {
         if (!signatureTool.isEmptySignature()) {
           signatureTool.one('annotationAdded', annot => {
@@ -41,11 +41,11 @@ export default store => evt => {
         }
       }, 100));
     } else {
-      const disableOnetimeListeners = () => {
+      const disableOnetimeListeners = _.once(() => {
         signatureTool.off('annotationAdded', onAnnotationAdded);
         signatureTool.off('signatureSaved', onAnnotationAdded);
-      };
-      const onAnnotationAdded = sigs => {
+      });
+      const onAnnotationAdded = _.once(sigs => {
         const sig = _.head(_.castArray(sigs));
         sig.CustomData.type = sigwigType;
         sig.CustomData.sigWigId = id;
@@ -53,18 +53,17 @@ export default store => evt => {
         sig.setCustomData('widgetId', id);
         signatureTool.setSignature(sig);
         signatureTool.off('signatureModalClosed', disableOnetimeListeners);
-      };
+      });
 
-      
-      signatureTool.one('annotationAdded', onAnnotationAdded);
-      signatureTool.one('signatureSaved', onAnnotationAdded);
+      signatureTool.on('annotationAdded', onAnnotationAdded);
+      signatureTool.on('signatureSaved', onAnnotationAdded);
 
-      signatureTool.one('signatureModalClosed', disableOnetimeListeners);
+      signatureTool.on('signatureModalClosed', disableOnetimeListeners);
       return store.dispatch(actions.openSignatureModal(sigwigType ? sigwigType : 'signature', sigWig.Id));
     }
   }
 
-  
+
   if (!signatureTool.isEmptySignature()) {
     signatureTool.addSignature();
   } else {


### PR DESCRIPTION
Thanks to Carlos for letting me know that .one() calls are not cleared
by .off() calls! This replaces some .one()s with some .on()s and uses
_.once to ensure the function is only called at most once